### PR TITLE
Makefile.am: put libraries in reverse-dependency order

### DIFF
--- a/src/frontend/Makefile.am
+++ b/src/frontend/Makefile.am
@@ -3,12 +3,12 @@ AM_CXXFLAGS = $(PICKY_CXXFLAGS)
 
 bin_PROGRAMS = koho-client
 koho_client_SOURCES = koho-client.cc trivial_queue.hh
-koho_client_LDADD = -lrt ../util/libutil.a ../tcp_splitter/libtcpsplitter.a ../packet/libpacket.a
+koho_client_LDADD = -lrt ../packet/libpacket.a ../tcp_splitter/libtcpsplitter.a ../util/libutil.a
 koho_client_LDFLAGS = -pthread
 
 bin_PROGRAMS += koho-server
 koho_server_SOURCES = koho-server.cc trivial_queue.hh
-koho_server_LDADD = -lrt ../util/libutil.a ../tcp_splitter/libtcpsplitter.a ../packet/libpacket.a
+koho_server_LDADD = -lrt ../packet/libpacket.a ../tcp_splitter/libtcpsplitter.a ../util/libutil.a
 koho_server_LDFLAGS = -pthread
 
 install-exec-hook:


### PR DESCRIPTION
Libraries need to be linked in reverse dependency order (reverse of the order they are in src/Makefile.am).
